### PR TITLE
Skip falsy arguments.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = function extend (object) {
     var args = Array.prototype.slice.call(arguments, 1);
 
     // For each extender, copy their properties on our object.
-    for (var i = 0, source; source = args[i]; i++) {
+    for (var i = 0, l = args.length, source; source = args[i], i < l; i++) {
         if (!source) continue;
         for (var property in source) {
             object[property] = source[property];

--- a/test/extend.js
+++ b/test/extend.js
@@ -19,6 +19,11 @@ test('should add new properties', function () {
     object.should.eql({ a : 3, b : 2 });
 });
 
+test('should skip falsy arguments', function () {
+    extend(object, null, false, '', 0, { b : 3 });
+    object.should.eql({ a : 3, b : 3 });
+});
+
 test('should return the object', function () {
     extend(object).should.equal(object);
 });


### PR DESCRIPTION
Currently, if there is a falsy value anywhere in the arguments list, such as `extend(a, null, b)`, the extending loop will stop on `null`, because `; source = args[i];` is telling it so.
